### PR TITLE
Create CNAME

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+combine-org.github.io


### PR DESCRIPTION
This solves the next problem: "The problem is every time we merge, the gh-pages branch gets updated and the Custom Domain pointer gets lost.  We had this problem with the SBOL website at first too. "

Because it looks like the trick is to move the CNAME file into the static folder. That way when you compile and publish to the gh-pages the CNAME file is also transferred.