### PR TITLE
Adding placeholder for HARMONY 2023

### DIFF
--- a/content/authors/COMBINE-2022/_index.md
+++ b/content/authors/COMBINE-2022/_index.md
@@ -52,7 +52,7 @@ topics:
 # Organizational groups that you belong to (for People widget)
 #   Set this to `[]` or comment out if you are not using People widget.
 user_groups:
-- Events
+- Past Events
 
 ---
 <img src="/images/combine2022/COMBINE2022_logo.png" alt="demo" class="img-responsive">

--- a/content/authors/HARMONY-2023/_index.md
+++ b/content/authors/HARMONY-2023/_index.md
@@ -1,0 +1,66 @@
+---
+title: Harmony 2023
+
+# Is this the primary user of the site?
+superuser: false
+
+conf_date: 25-28, April 2023
+
+conf_location:  Seattle, WA
+
+important_dates:
+# - name: Breakout submission deadline
+#  date: April 4, 2022
+# - name: Lightning talk submission deadline
+#  date: April 4, 2022
+# - name: Notification of acceptance of breakouts
+#  date: April 6, 2022
+- name: HARMONY Workshop
+  date: April 25 to 28, 2023
+
+important_links:
+- name: Agenda
+  link: https://combine-org.github.io/events/
+# - name: Registration
+#  link: https://forms.gle/AvdPZ5pLNSWBtZWq5
+# - name: Breakout submission
+#  link: https://forms.gle/8Q8iSn16VWmuGWgh7
+
+information:
+# - name: Registration
+#  description: Registration for the meeting is open and is free. Please register at the link above as soon as possible. This will help us plan the schedule and match your interests to the timing of the breakouts, etc. Note, only registered attendees will be sent information related to video conferencing links, etc.
+#  link: https://forms.gle/AvdPZ5pLNSWBtZWq5
+# - name: Call for Breakout Sessions
+#  description: All attendees can suggest breakout sessions for hacking and/or detailed discussions of certain aspects of one or several of the COMBINE standard(s), metadata and semantic annotations (format-specific or overarching), application and implementations of the COMBINE standards, or any other topic relevant for the COMBINE community. The topics for those breakout sessions, and the time slots which would suit their communities can be submitted via the link above. Note, breakout session organisers will be responsible for creating and hosting their own online sessions.
+#  link: https://forms.gle/8Q8iSn16VWmuGWgh7
+# - name: Call for Lightning Talks
+#  description: Requests for a lightning talk (3 min max.) can be submitted via the link above. Please use several forms if you want to submit abstracts on different topics. The submission deadline is outlined above. Talks will take place during the community session.
+#  link: https://forms.gle/QbQfmDPYUi2pHy5W7
+
+topics:
+- Data exchange, pipelines and model standards for systems and synthetic biology
+- Visualization and graphical notation standards for systems and synthetic biology
+- Standards for sharing and analysing biological pathway data
+- Standards for computational biological models and modelling support
+- Metadata description and model annotation in COMBINE standard formats
+- Implementation of COMBINE standards in tools, databases and other resources
+- Integrated model and data management for systems and synthetic biology
+- Standardization of Artificial Intelligence approaches in biological modelling
+- Emerging standardization needs and multicellular modeling
+- Community aspects of COMBINE
+
+# Organizational groups that you belong to (for People widget)
+#   Set this to `[]` or comment out if you are not using People widget.
+user_groups:
+- Events
+
+---
+The Computational Modeling in Biology Network (COMBINE) is an initiative to coordinate the development of the various community standards and formats in systems biology, synthetic biology and related fields. HARMONY is a codefest-type meeting, with a focus on development of the standards, interoperability and infrastructure. There are generally not many general discussions or oral presentations during HARMONY; instead, the time is devoted to allowing hands-on hacking and interaction between people focused on practical development of software and standards.
+
+HARMONY 2023 will be hosted by Herbert Sauro and the Center for Reproducible Biomedical Modeling at the University of Washington, Seattle, WA. It is going to be organized primarily as an in-person meeting, with individual breakout sessions responsible for enabling remote participation as needed.
+
+Most of each day will be scheduled by the communities as breakouts. In addition, we will have some time each day for community discussion and wrap-ups of breakouts and advertisements for following breakouts.
+
+<h1>Workshop Location Details</h1>
+
+HARMONY 2023 takes place at the University of Washington (UW, and commonly called "U-Dub") in Seattle, Washington. HARMONY 2023 will take place in the William H. Foege Bioengineering building, more details will be forthcoming.

--- a/content/events/current.md
+++ b/content/events/current.md
@@ -10,5 +10,5 @@ title = ""
 # Choose the user profile to display
 # This should be the username of a profile in your `content/authors/` folder.
 # See https://sourcethemes.com/academic/docs/get-started/#introduce-yourself
-author = "COMBINE-2022"
+author = "HARMONY-2023"
 +++


### PR DESCRIPTION
Adding initial placeholder for HARMONY 2023 meeting with available information. Not sure I have all the places that changes are needed to update the main events page. Fixes #126 