### PR TITLE
Change workflows to use ubuntu-latest

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
         with:


### PR DESCRIPTION
Presumably this will break something in the future when things get updated and aren't backwards-compatible.  But as long as things remain compatible, it at least means we won't need to keep changing the ubuntu version by hand every two years.