### PR TITLE
This is adding a full display for "events" and "future events"

### DIFF
--- a/content/authors/COMBINE_2023/_index.md
+++ b/content/authors/COMBINE_2023/_index.md
@@ -36,7 +36,7 @@ information:
   description: Registration for the meeting is open and is free. Please register at the link on the left as soon as possible. This will help us plan the schedule and match your interests to the timing of the breakouts, etc.
   link: TBD
 - name: Organizers
-  description: The COMBINE 2022 meeting is organised by Dagmar Waltemath and Matthias König.
+  description: The COMBINE 2023 meeting is organised by Dagmar Waltemath and Matthias König.
   link: ../people/
 
 topics:
@@ -49,7 +49,7 @@ user_groups:
 
 ---
 
-The "**Computational Modeling in Biology**" Network (**COMBINE**) is an initiative to coordinate the development of the various community standards and formats in systems biology and related fields. COMBINE 2022 will be a workshop-style event with oral presentations, breakout sessions and tutorials. The three meeting days will include talks about the COMBINE standards and associated or related standardization efforts, presentations of tools using these standards, breakout sessions for detailed discussions as well as tutorials.
+The "**Computational Modeling in Biology**" Network (**COMBINE**) is an initiative to coordinate the development of the various community standards and formats in systems biology and related fields. COMBINE 2023 will be a workshop-style event with oral presentations, breakout sessions and tutorials. The three meeting days will include talks about the COMBINE standards and associated or related standardization efforts, presentations of tools using these standards, breakout sessions for detailed discussions as well as tutorials.
 
 
 <h1>Agenda</h1>

--- a/content/authors/COMBINE_2023/_index.md
+++ b/content/authors/COMBINE_2023/_index.md
@@ -8,19 +8,21 @@ conf_date: XX-XX 2023
 
 conf_location: TBD
 
-# important_dates:
-# - name: Breakout/tutorial submission deadline
-#   date: ~~August 26, 2022~~ September 10, 2022
-# - name: Forum abstract submission deadline
-#   date: ~~August 26, 2022~~ September 30, 2022
-# - name: Initial notification of acceptance (and then ongoing)
-#  date: September 9, 2022
+important_dates:
+- name: Breakout submission deadline (for initial scheduling)
+  date: April 2, 2023
+- name: Lightning talk and poster submission deadline
+  date: April 2, 2023
+- name: Notification of acceptance of breakouts and abstracts
+  date: April 7, 2023
+- name: HARMONY Workshop
+  date: April 24 to 27, 2023
 
-important_links:
-- name: Registration
-  link: TBD
-- name: Zoom stream registration
-  link: TBD
+# important_links:
+# - name: Registration
+#   link: TBD
+# - name: Zoom stream registration
+#   link: TBD
 
 # - name: Breakouts/Tutorials submission
 #   link: https://forms.gle/4VHZTxR5FcY2GLhR8
@@ -46,7 +48,6 @@ user_groups:
 - Future Events
 
 ---
-<img src="/images/combine2022/COMBINE2022_logo.png" alt="demo" class="img-responsive">
 
 The "**Computational Modeling in Biology**" Network (**COMBINE**) is an initiative to coordinate the development of the various community standards and formats in systems biology and related fields. COMBINE 2022 will be a workshop-style event with oral presentations, breakout sessions and tutorials. The three meeting days will include talks about the COMBINE standards and associated or related standardization efforts, presentations of tools using these standards, breakout sessions for detailed discussions as well as tutorials.
 

--- a/layouts/authors/list.html
+++ b/layouts/authors/list.html
@@ -37,7 +37,7 @@
 <section id="profile-page" class="pt-5">
   <div class="container">
     {{/* Show the About widget if an account exists for this user. */}}
-    {{ if .File }}
+    {{ if and .File (not (intersect .Params.user_groups (slice "Future Events" "Events"))) }}
       {{ $widget := "widgets/about.html" }}
       {{ $username := (path.Base (path.Split .Path).Dir) }}{{/* Alternatively, use `index .Params.authors 0` */}}
       {{ $params := dict "root" $ "page" . "author" $username }}

--- a/layouts/authors/list.html
+++ b/layouts/authors/list.html
@@ -63,39 +63,86 @@
       {{ end  }}
     {{end}}
 
-
-    {{/* If _index.md exists for the author look through all site pages */}}
-    {{/* and display the articles that have an author equal to any of the names */}}
-    {{/* listed in the _index.md page */}}
-    {{ if .File }}
-      {{ $query := where .Site.Pages ".IsNode" false }}
-      {{ $count := len $query }}
-      {{ $list := .Params.names}}
-      {{ $research_tags := .Params.research_area_tags}}
-
-
-    {{end}}
-
-    {{/* If no _index.md file exists for the author */}}
-    {{/* list papers that have the same exact author listed */}}
-    {{ if not .File }}
-        {{ $query := where .Pages ".IsNode" false }}
-        {{ $count := len $query }}
-
-        {{ if $count }}
-        <div class="article-widget content-widget-hr">
-          <h3>{{ i18n "user_profile_latest" | default "Latest" }}</h3>
-          <ul>
-            {{ range $query }}
-                <li>
-                  <a href="{{ .RelPermalink }}">{{ .Title }}</a>
-                </li>
-            {{ end }}
-          {{end}}
-          </ul>
+    {{/* Display the event layout for current and future events. */}}
+    {{ if and .File (intersect .Params.user_groups (slice "Future Event" "Events")) }}
+    
+      {{ $person := .Params }}
+      <div class="row">
+        <div class="col-12 col-lg-4">
+          <h1 style="color:rgb(31, 100, 107)">{{ $person.title }}</h1>
         </div>
-    {{end}}
-  </div>
-</section>
-
+      </div>
+    
+      <div class="row">
+        <div class="col-12 col-lg-4">
+          <!-- Conference date -->
+          <h2 style="color:rgb(141, 199, 66)">Conference Date</h2>
+          <b>{{ $person.conf_date }}</b>
+    
+          <!-- Conference Location -->
+          <h2 style="color:rgb(141, 199, 66)">Conference Location</h2>
+          <b>{{ $person.conf_location }}</b>
+    
+          <!-- Important Dates -->
+          {{ with $person.important_dates }}
+            <h2 style="color:rgb(141, 199, 66)">Important Dates</h2>
+            {{ range . }}
+              <div>{{ .name | markdownify | emojify }}</div>
+              <b>{{ .date | markdownify | emojify }}</b>
+              <p></p>
+            {{ end }}
+          {{ end }}
+    
+          <!-- Important Links -->
+          {{ with $person.important_links }}
+            <h2 style="color:rgb(141, 199, 66)">Important Links</h2>
+            {{ range . }}
+              <div class="description"><a href={{ .link }} style="color:rgb(31, 100, 107)">{{ .name | markdownify | emojify }}</a></div>
+            {{ end }}
+          {{ end }}
+        </div>
+    
+        <div class="col-12 col-lg-8">
+          <!-- Overview -->
+          <p></p>
+          {{ .Content }}
+    
+          <!-- Information -->
+          {{ with $person.information }}
+            {{ range .}}
+              {{ if .link }}
+                <h2><a href={{ .link }} target="_blank" rel="noopener"><span style="color:rgb(141, 199, 66)">{{ .name }}</span> <i class="fas fa-chevron-right" aria-hidden="true"></i></a></h2>
+              {{ else }}
+                <h2 style="color:rgb(141, 199, 66)"><b>{{ .name }}</b></h2>
+              {{ end }}
+    
+              {{ .description }}
+            {{ end }}
+          {{ end }}
+    
+          <!-- Topics of interest -->
+          {{ with $person.topics }}
+            <h2 style="color:rgb(141, 199, 66)">Topics of Interest</h2>
+            <ul>
+              {{ range . }}
+              <li>
+                {{ . }}
+              </li>
+              {{ end }}
+            </ul>
+          {{ end }}
+        </div>
+      </div>
+      {{ else }}
+  <!-- Existing layout for people's and other event pages -->
+  {{/* If _index.md exists for the author look through all site pages */}}
+  {{/* and display the articles that have an author equal to any of the names */}}
+  {{/* listed in the _index.md page */}}
+  {{ if .File }}
+    {{ $query := where .Site.Pages ".IsNode" false }}
+    {{ $count := len $query }}
+    {{ $list := .Params.names}}
+    {{ $research_tags := .Params.research_area_tags}}
+  {{ end }}
+  {{ end }}
 {{- end -}}

--- a/layouts/authors/list.html
+++ b/layouts/authors/list.html
@@ -64,7 +64,7 @@
     {{end}}
 
     {{/* Display the event layout for current and future events. */}}
-    {{ if and .File (intersect .Params.user_groups (slice "Future Event" "Events")) }}
+    {{ if and .File (intersect .Params.user_groups (slice "Future Events" "Events")) }}
     
       {{ $person := .Params }}
       <div class="row">


### PR DESCRIPTION
This PR closes #134 and #135 .

I have changed the layouts so that **Future Events** and **Current Events** are displayed with all the information (important links, important dates) but leaves **Past Events** as they were (with less information displayed).