### PR TITLE
Fixed broken links on the "Standards" page

### DIFF
--- a/content/authors/CellML/_index.md
+++ b/content/authors/CellML/_index.md
@@ -46,4 +46,4 @@ CellML development is coordinated by an <a rel="nofollow" class="external text" 
 
 APIs are available to help implementing support: <a rel="nofollow" class="external text" href="https://libcellml.org">libCellML</a> in C++, with Python and Javascript bindings available.
 
-<a rel="nofollow" class="external text" href="http://co.mbine.org/standards/CellML">More information.</a>
+<a rel="nofollow" class="external text" href="https://www.cellml.org/about">More information.</a>

--- a/content/authors/SBML/_index.md
+++ b/content/authors/SBML/_index.md
@@ -41,4 +41,4 @@ The latest stable specification is <a rel="nofollow" class="external text" href=
 
 SBML development is <a rel="nofollow" class="external text" href="http://sbml.org/About"> coordinated</a> by an elected editorial board and central developer team.
 
-Over 250 software systems known to support SBML can be found in the <a rel="nofollow" class="external text" href="http://sbml.org/SBML_Software_Guide"> SBML software guide</a>.  APIs are available to help implementing support: <a rel="nofollow" class="external text" href="http://sbml.org/Software/libSBML"> libSBML</a> in C++ and <a rel="nofollow" class="external text" href="http://sbml.org/Software/JSBML"> JSBML</a> in Java.
+Over 250 software systems known to support SBML can be found in the SBML software documentation.  APIs are available to help implementing support: <a rel="nofollow" class="external text" href="http://sbml.org/Software/libSBML"> libSBML</a> in C++ and <a rel="nofollow" class="external text" href="http://sbml.org/Software/JSBML"> JSBML</a> in Java.

--- a/content/authors/SBOL-Visual/_index.md
+++ b/content/authors/SBOL-Visual/_index.md
@@ -33,8 +33,8 @@ user_groups:
 
 The <a rel="nofollow" class="external text" href="http://sbolstandard.org/visual/">Synthetic Open Language Visual (SBOL Visual)</a> is an open-source graphical notation that uses schematic “glyphs” to specify genetic parts, devices, modules, and systems.
 
-The latest stable specification of SBOL Visual is <a rel="nofollow" class="external text" href="http://sbolstandard.org/wp-content/uploads/2017/10/SBOLVisual_Specification_2_0_0.pdf">2.0.0</a>.
+The latest stable specification of SBOL Visual is <a rel="nofollow" class="external text" href="https://sbolstandard.org/docs/SBOLVisual_Specification_2_0_0.pdf">2.0.0</a>.
 
-SBOL is developed by the <a rel="nofollow" class="external text" href="http://sbolstandard.org/developers/">SBOL Developers Group</a> and <a rel="nofollow" class="external text" href="http://sbolstandard.org/visual-2/">SBOL Visual Group</a>. The development is coordinated by an <a rel="nofollow" class="external text" href="http://sbolstandard.org/gov/">editorial board and the SBOL Chair</a>.
+SBOL is developed by the SBOL Developers Group and SBOL Visual Group. The development is coordinated by an <a rel="nofollow" class="external text" href="https://sbolstandard.org/community-governance/">editorial board and the SBOL Chair</a>.
 
-SBOL Visual is supported by many <a rel="nofollow" class="external text" href="http://sbolstandard.org/software/tools/">software tools</a>.
+SBOL Visual is supported by many <a rel="nofollow" class="external text" href="https://sbolstandard.org/#applications">software tools</a>.

--- a/content/authors/SBOL/_index.md
+++ b/content/authors/SBOL/_index.md
@@ -33,7 +33,7 @@ user_groups:
 
 The <a rel="nofollow" class="external text" href="http://www.sbolstandard.org/">Synthetic Biology Open Language Data (SBOL Data)</a> is a language for the description and the exchange of synthetic biological parts, devices and systems. 
 
-The latest stable specification of SBOL Data is <a rel="nofollow" class="external text" href="http://co.mbine.org/specifications/sbol.version-3.0.0.pdf">3.0.0</a>.
+The latest stable specification of SBOL Data is <a rel="nofollow" class="external text" href="https://sbolstandard.org/docs/SBOL3.0.0.pdf">3.0.0</a>.
 
 SBOL Data is developed by the <a rel="nofollow" class="external text" href="https://sbolstandard.org/community/">SBOL Developers Group</a>. The development is coordinated by an <a rel="nofollow" class="external text" href="https://sbolstandard.org/community-governance/">editorial board and the SBOL Chair</a>.
 

--- a/content/authors/SED-ML/_index.md
+++ b/content/authors/SED-ML/_index.md
@@ -33,10 +33,8 @@ user_groups:
 
 The <a rel="nofollow" class="external text" href="http://sed-ml.org/">Simulation Experiment Description Markup Language (SED-ML)</a> is an XML-based format for encoding simulation experiments. SED-ML allows to define the models to use, the experimental tasks to run and which results to produce.is a computer-readable format for representing the models of biological processes. SED-ML can be used with models encoded in several languages, as far as they are in XML.
 
-The latest stable specification is <a rel="nofollow" class="external text" href="http://co.mbine.org/specifications/sed-ml.level-1.version-3.pdf">Level 1 Version 3</a>.
+The latest stable specification is <a rel="nofollow" class="external text" href="https://sed-ml.org/documents/sed-ml-L1V3.pdf">Level 1 Version 3</a>.
 
 SED-ML development is coordinated by an <a rel="nofollow" class="external text" href="http://sed-ml.org/about.html">elected editorial board</a>.
 
-APIs are available to help implementing support: <a rel="nofollow" class="external text" href="http://libsedml.sourceforge.net/libSedML/Welcome.html">libSedML</a> in C#, <a rel="nofollow" class="external text" href="https://github.com/fbergmann/libSEDML">libSEDML</a> in C++ with swig bindings for python, java, perl, R and ruby, and <a rel="nofollow" class="external text" href="https://github.com/fbergmann/libSEDMLML/Welcome.html">jlibsedml</a> in Java.
-
-<a rel="nofollow" class="external text" href="http://co.mbine.org/standards/sed-ml">More information</a>
+APIs are available to help implementing support: <a rel="nofollow" class="external text" href="http://libsedml.sourceforge.net/libSedML/Welcome.html">libSedML</a> in C#, <a rel="nofollow" class="external text" href="https://github.com/fbergmann/libSEDML">libSEDML</a> in C++ with swig bindings for python, java, perl, R and ruby, and jlibsedml in Java.


### PR DESCRIPTION
Most broken links have been replaced with up to date pages, but a few broken links (where no equivalent pages could be found) have been removed