### PR TITLE
Set Harmony 2024 as upcoming conference

### DIFF
--- a/content/home/current.md
+++ b/content/home/current.md
@@ -10,5 +10,5 @@ title = "Upcoming Conferences"
 # Choose the user profile to display
 # This should be the username of a profile in your `content/authors/` folder.
 # See https://sourcethemes.com/academic/docs/get-started/#introduce-yourself
-author = "COMBINE_2024"
+author = "HARMONY-2024"
 +++


### PR DESCRIPTION
Fixes https://github.com/combine-org/combine-org.github.io/issues/221 

FYI @shoepfl, apparently only one upcoming conference can be put in this section on the homepage. This can be changed to Combine 2024 in a few weeks. It still appears as a link on the bottom of https://co.mbine.org/events/