### PR TITLE
Changed Combine2024 to current Event

### DIFF
--- a/content/authors/COMBINE_2024/_index.md
+++ b/content/authors/COMBINE_2024/_index.md
@@ -53,7 +53,7 @@ topics:
 # Organizational groups that you belong to (for People widget)
 #   Set this to `[]` or comment out if you are not using People widget.
 user_groups:
-- Future Events
+- Events
 
 
 ---

--- a/content/authors/HARMONY-2024/_index.md
+++ b/content/authors/HARMONY-2024/_index.md
@@ -57,7 +57,7 @@ topics:
 # Organizational groups that you belong to (for People widget)
 #   Set this to `[]` or comment out if you are not using People widget.
 user_groups:
-- Events
+- Past Events
 
 ---
 


### PR DESCRIPTION
Harmony was in April so Combine2024 should now be listed under the upcoming conferences