### PR TITLE
Fix URLs for child care resources

### DIFF
--- a/content/authors/COMBINE-2026/_index.md
+++ b/content/authors/COMBINE-2026/_index.md
@@ -159,7 +159,7 @@ Please check <a href="https://www.gov.uk/check-uk-visa">here</a> if you require 
 The COMBINE community is dedicated to providing a harassment-free experience for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), or technology choices. We do not tolerate harassment of participants in our meetings, email list, and other communication mechanisms in any form. Sexual language and imagery is not appropriate for any of these venues, including talks, workshops, parties, email lists, Twitter and other online media. Participants in our meetings and discussions violating these rules may be sanctioned or expelled from our mailing lists and our meetings without a refund at the discretion of the COMBINE coordinators. This policy is linked on the COMBINE website.
 
 <h3> Child Care Availabilty & Local Resources </h3>
-COMBINE 2026 does not provide child care, however local resources for short-term child care may be available through <a href="childcare.co.uk">childcare.co.uk</a>, <a href="nannyjob.co.uk">nannyjob.co.uk</a>, or similar services.  Additional information/resources will be shared as they become available. 
+COMBINE 2026 does not provide child care, however local resources for short-term child care may be available through <a href="https://childcare.co.uk">childcare.co.uk</a>, <a href="https://nannyjob.co.uk">nannyjob.co.uk</a>, or similar services.  Additional information/resources will be shared as they become available. 
 
 
 <h3>Support</h3>


### PR DESCRIPTION
Updated URLs for local child care resources to include 'https://'.